### PR TITLE
Fix typo in MNCDoctrineCarbonExtension

### DIFF
--- a/DependencyInjection/MNCDoctrineCarbonExtension.php
+++ b/DependencyInjection/MNCDoctrineCarbonExtension.php
@@ -23,7 +23,7 @@ class MNCDoctrineCarbonExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('carbon.default_locale',
-            isset($cofig['locale']) ? $config['locale'] : $container->getParameter('locale'));
+            isset($config['locale']) ? $config['locale'] : $container->getParameter('locale'));
 
         $container->setParameter('mnc_doctrine_carbon.properties', $config['properties']);
         $container->setParameter('mnc_doctrine_carbon.excluded_entities', $config['excluded_entities']);


### PR DESCRIPTION
Hello @mnavarrocarter, I was looking at your `DoctrineCarbonBundle` and noticed a typo inside `MNCDoctrineCarbonExtension`. Feel free to accept it ^^.